### PR TITLE
Support Android Q, by using new FFMpeg lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Surprisingly fast on device video transcoding.
 Features
 
 - extracting images from video either ffmpeg or mediacodec
-- creating video from image seither ffmpeg or mediacodec
+- creating video from image either ffmpeg or mediacodec
 
 [![Screenshot](screenshot.png)](screenshot.png)
 
@@ -112,8 +112,8 @@ Step 2. Add the dependency
 dependencies {
 	implementation 'com.exozet:transcoder:{version}'
 
-	//Need to add ffmpeg dependencies if want to use FFMpegTranscoder(tested version 1.1.7)
-	implementation 'nl.bravobit:android-ffmpeg:{version}'
+	//Need to add ffmpeg dependencies if want to use FFMpegTranscoder(tested version 4.3.1.LTS)
+	implementation 'com.arthenica:mobile-ffmpeg-full-gpl:{version}'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,7 @@ dependencies {
 
     implementation libs.numberprogressbar
 
-    implementation libs.androidFfmpeg
+    implementation libs.androidFfmpegNew
 }
 
 // region override support library version

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,12 +8,13 @@
 
     <application
             android:icon="@mipmap/ic_launcher"
+        android:requestLegacyExternalStorage="true"
             android:label="@string/app_name"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
             tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.exozet.transcoder.ffmpeg.demo.DemoActivity">
+        <activity android:name="com.exozet.transcoder.ffmpeg.demo.FFmpegActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/exozet/transcoder/ffmpeg/demo/DemoActivity.kt
+++ b/app/src/main/java/com/exozet/transcoder/ffmpeg/demo/DemoActivity.kt
@@ -67,8 +67,6 @@ class DemoActivity : FragmentActivity() {
 
             var progress: Progress? = null
 
-
-
             MediaCodecTranscoder.createVideoFromFrames(
                 frameFolder = frameFolder,
                 outputUri = outputVideo,

--- a/app/src/main/java/com/exozet/transcoder/ffmpeg/demo/FFmpegActivity.kt
+++ b/app/src/main/java/com/exozet/transcoder/ffmpeg/demo/FFmpegActivity.kt
@@ -100,9 +100,8 @@ class FFmpegActivity : AppCompatActivity() {
             }
 
 
-            //extractByFFMpeg(inputVideo,frameFolder)
-
-            extactByMediaCodec(times, inputVideo, frameFolder)
+            extractByFFMpeg(inputVideo,frameFolder)
+            //extactByMediaCodec(times, inputVideo, frameFolder)
 
         }
     }
@@ -110,11 +109,8 @@ class FFmpegActivity : AppCompatActivity() {
     private fun mergeFrames(frameFolder: Uri, outputVideo: Uri) {
 
         make_video.onClick {
-
-            //mergeByFFMpeg(frameFolder,outputVideo)
-
-            mergeByMediaCodec(frameFolder, outputVideo)
-
+            mergeByFFMpeg(frameFolder,outputVideo)
+            //mergeByMediaCodec(frameFolder, outputVideo)
         }
     }
 
@@ -127,7 +123,6 @@ class FFmpegActivity : AppCompatActivity() {
             output.text = ""
 
             FFMpegTranscoder.transcode(
-                context = this,
                 inputVideo = inputVideo,
                 outputUri = outputVideo
             )
@@ -191,7 +186,6 @@ class FFmpegActivity : AppCompatActivity() {
         output.text = ""
 
         FFMpegTranscoder.createVideoFromFrames(
-            context = this,
             frameFolder = frameFolder,
             outputUri = outputVideo,
             config = EncodingConfig(

--- a/transcoder/build.gradle
+++ b/transcoder/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation libs.rx2java
     implementation libs.rx2Android
     implementation libs.rx2Kotlin
-    compileOnly libs.androidFfmpeg
+    compileOnly libs.androidFfmpegNew
 }
 
 configurations.all {


### PR DESCRIPTION
Ticket: #134586
Android Q seems that it does not permit to run FFMpeg from the files directories anymore.
The current used ffmpeg lib still doesn't have a fix for this issue yet. so i used a new FFMpeg library which supports Android Q.
This modification shouldn't break the implementation of anyone who uses TransCoder lib, except that we don't need to pass context parameter to FFMpeg methods anymore.
As i mentioned the new lib dependency in README as well.
Kindly check.